### PR TITLE
Use owned feature of meshtext to prevent leaking the font data.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 bitflags = "1.2"
 anyhow = "1.0"
 glyph_brush_layout = "0.2.3"
-meshtext = "0.2.1"
+meshtext = { version = "0.3.0", features = ["owned"] }
 
 [dependencies.bevy]
 version = "0.9.0"

--- a/src/font_loader.rs
+++ b/src/font_loader.rs
@@ -13,11 +13,10 @@ impl AssetLoader for FontLoader {
         load_context: &'a mut LoadContext,
     ) -> BoxedFuture<'a, Result<()>> {
         let bytes: Vec<u8> = bytes.into();
-        let bytes = bytes.leak();
 
         Box::pin(async move {
             // standard bevy_text/src/font_loader code
-            let font = Font::try_from_bytes(bytes.into())?;
+            let font = Font::try_from_bytes(bytes.clone())?;
             load_context.set_default_asset(LoadedAsset::new(font));
 
             let common =
@@ -45,7 +44,7 @@ impl AssetLoader for FontLoader {
 #[derive(TypeUuid)]
 #[uuid = "5415ac03-d009-471e-89ab-dc0d4e31a8c4"]
 pub struct TextMeshFont {
-    pub(crate) ttf_font_generator: meshtext::MeshGenerator,
+    pub(crate) ttf_font_generator: meshtext::MeshGenerator<meshtext::OwnedFace>,
 }
 
 impl std::fmt::Debug for TextMeshFont {

--- a/src/mesh_data_generator.rs
+++ b/src/mesh_data_generator.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use meshtext::{Glyph, MeshGenerator};
+use meshtext::{Glyph, MeshGenerator, OwnedFace};
 
 use crate::{
     mesh_cache::{CacheKey, MeshCache},
@@ -20,7 +20,7 @@ pub(crate) struct MeshData {
 // from the existing mesh
 pub(crate) fn generate_text_mesh(
     text_mesh: &TextMesh,
-    font: &mut MeshGenerator,
+    font: &mut MeshGenerator<OwnedFace>,
     cache: Option<&mut MeshCache>,
 ) -> MeshData {
     trace!("Generate text mesh: {:?}", text_mesh.text);
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn test_generate_mesh() {
         let mut mesh_cache = MeshCache::default();
-        let bytes = get_font_bytes().leak();
+        let bytes = get_font_bytes();
         let mut font = MeshGenerator::new(bytes);
 
         let text_mesh = TextMesh {


### PR DESCRIPTION
Initially I thought I was able to make this change without making a breaking change in `meshtext`, but ulitmately had to realise that version `0.2.2` was not compatible with `0.2.0` because of the introduced generics, so I had to bump the version.
Long story short, this is how it should work now without leaking the data. Apart from the now different scaling (I suppose) the examples look fine.